### PR TITLE
Set working directory to `irpf.jar` location in wrapper script

### DIFF
--- a/br.gov.fazenda.receita.irpf2026.yaml
+++ b/br.gov.fazenda.receita.irpf2026.yaml
@@ -61,7 +61,7 @@ modules:
       - type: script
         dest-filename: irpf2026
         commands:
-          - exec java -jar /app/extra/share/irpf.jar $@
+          - cd /app/extra/share && exec java -jar irpf.jar $@
       - type: file
         path: br.gov.fazenda.receita.irpf2026.metainfo.xml
       - type: file


### PR DESCRIPTION
This fixes an issue that would prevent us from visualizing the tax receipt.

Steps to reproduce:

1. Menu Declaração > Imprimir > Declaração
2. Select a Declaração, hit OK
3. Select Toda a Declaração
4. Select Visualizar
5. Hit Ok

Wait a few seconds, nothing will happen. Check the log file at `~/ProgramasRFB/IRPF2026/IRPF2026.log` and notice a long Java exception:

```
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Caused by: java.io.FileNotFoundException: lib/resources/paises.xml (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
	at groovy.util.CharsetToolkit.<init>(CharsetToolkit.java:78)
```

Fixes #8